### PR TITLE
Add helper functions to use as implicit-solvent post-processing

### DIFF
--- a/ForceField/Forcefield.py
+++ b/ForceField/Forcefield.py
@@ -46,11 +46,12 @@ class _generic_force_field:
         nonbondedCutoff=1*nanometer):
 
         if self.water_model == "implicit":
-            return self._openmm_forcefield.createSystem(topology=topology,nonbondedMethod=NoCutoff,constraints=HBonds)
+            self._system = self._openmm_forcefield.createSystem(topology=topology,nonbondedMethod=NoCutoff,constraints=HBonds)
         else:
             print("built explicit System",nonbondedMethod,nonbondedCutoff)
-            return self._openmm_forcefield.createSystem(topology=topology,nonbondedMethod=nonbondedMethod,
+            self._system = self._openmm_forcefield.createSystem(topology=topology,nonbondedMethod=nonbondedMethod,
                                                     nonbondedCutoff=nonbondedCutoff,constraints=HBonds)
+        return self._system
 
 
     def __str__(self):
@@ -86,11 +87,14 @@ class OpenFF_forcefield(_generic_force_field):
         topology.add_molecule(self._solute)
         topology = topology.to_openmm()
         
+        self._generator_outputs = []
         for res in topology.residues():
-            smirnoff.generator(forcefield,res)
+            self._generator_outputs.append(smirnoff.generator(forcefield,res))
     
         super().__init__(force_field = forcefield)
         self._ready_for_usage = True
+        self._smirnoff = smirnoff
+        self._topology = topology
 
     def create_system(self, topology, nonbondedMethod=PME, nonbondedCutoff=1 * nanometer):
         return super().create_system(topology, nonbondedMethod, nonbondedCutoff)

--- a/MachineLearning/GNN_Models.py
+++ b/MachineLearning/GNN_Models.py
@@ -355,7 +355,15 @@ class GNN3_all_swish_multiple_peptides_GBNeck_trainable_dif_graphs_corr_with_sep
 
         return 0
 
-    def forward(self, positions):
+    def forward(self, positions, return_energy_tensors=False):
+        """Compute the NN implicit solvent energy for given positions.
+
+        :param positons: torch.tensor (on the correct device!) with the positions.
+        :param return_energy_tensors: if True, return a dict with keys
+            "polar_energy" and "apolar_energy", where each value is a
+            torch.tensor with length n_atoms. Otherwise, return the total
+            energy as a 0-dimensional torch tensor (single value).
+        """
 
         # Build Graph
         _, edge_index, edge_attributes = self.build_graph(positions)
@@ -396,6 +404,9 @@ class GNN3_all_swish_multiple_peptides_GBNeck_trainable_dif_graphs_corr_with_sep
 
         # Evaluate GB energies
         energies = self.calculate_energies(x=Bc, edge_index=edge_index, edge_attributes=edge_attributes)
+
+        if return_energy_tensors:
+            return {"polar_energy": bo_energies, "apolar_energies": sa_energies}
 
         # Add SA term
         energies = energies + sa_energies


### PR DESCRIPTION
This adds some functionality for use-cases where we want to analyze a molecule with existing parameters, rather than newly parameterizing it. This is useful e.g., to get implicit-solvent energies for each frame of an existing trajectory in an MM-GBSA-like style. Additionally, I think that the prepare_torch_model function is useful for testing purposes. E.g., one can create a simple system of a few spheres and obtain its implicit solvent energies.

# Changes
* add a boolean flag to the "forward" method of GNN3_all_swish_multiple_peptides_GBNeck_trainable_dif_graphs_corr_with_separate_SA_run_multiple, to allow returning the polar and apolar energies per atom.
* add a helper function get_vdw_radii to obtain the VdW radii starting from an RDKit molecule
* add a helper function "prepare_torch_model" to takes radii and charges as input, and can returns a torch model that can be queried for the implicit-solvent energy of specific conformers.

# To do
Since I was working on an outdated branch, I would appreciate it if @katzberger could have a careful look at all the changes, to avoid breaking anything.